### PR TITLE
only update DNS when different

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.18.2
-RUN apk add --no-cache bash curl
+RUN apk add --no-cache bash bind-tools curl
 COPY cloudflare-ddns.sh /
 RUN chmod +x /cloudflare-ddns.sh
 ENTRYPOINT ["/cloudflare-ddns.sh"]

--- a/cloudflare-ddns.sh
+++ b/cloudflare-ddns.sh
@@ -25,6 +25,14 @@ fi
 : "${PROXIED:=false}"
 echo "Using IP: $IP" 1>&2
 
+# Dig the old IP and exit out if they are the same
+: "${OLD_IP:=$(dig +short @1.1.1.1 $NAME | tail -n1)}"
+echo "Using Old IP: $OLD_IP" 1>&2
+if [[ "${IP}" == "${OLD_IP}" ]]; then
+  echo "IP has not changed. Exiting..."
+  exit 0
+fi
+
 PAYLOAD="{\"type\":\"A\",\"name\":\"$NAME\",\"content\":\"$IP\",\"proxied\":$PROXIED,\"ttl\":1}"
 echo "Sending payload: $PAYLOAD" 1>&2
 


### PR DESCRIPTION
This PR updates the script to only update the DNS record in cloudflare when it changes. This should reduce the amount of API calls, since DNS entries tend not to change too often.

I have `dig` fetching directly from `1.1.1.1`, since we only care about cloudflare DNS entries, but let me know if you'd prefer to have it just use the container's upstream DNS servers instead.